### PR TITLE
Gods gain the capability of overwriting created_at

### DIFF
--- a/api/v1/posts.rb
+++ b/api/v1/posts.rb
@@ -130,7 +130,12 @@ class GroveV1 < Sinatra::Base
     response.status = 201 if @post.new_record?
 
     check_allowed @post.new_record? ? 'create' : 'update', @post do
-      (['external_document', 'document', 'paths', 'occurrences', 'tags', 'external_id', 'restricted'] & attributes.keys).each do |field|
+      allowed_attributes = ['external_document', 'document', 'paths', 'occurrences', 'tags', 'external_id', 'restricted']
+      # Gods have some extra fields they may update
+      if current_identity.god?
+        allowed_attributes += ['created_at']
+      end
+      (allowed_attributes & attributes.keys).each do |field|
         @post.send(:"#{field}=", attributes[field])
       end
 

--- a/spec/api/v1/posts_spec.rb
+++ b/spec/api/v1/posts_spec.rb
@@ -62,6 +62,13 @@ describe "API v1 posts" do
         last_response.status.should eq 404
       end
 
+      it "can't update timestamps" do
+        p = Post.create!(:uid => "post:a.b.c", :document => {'text' => '1'}, :created_by => 1)
+        post "/posts/#{p.uid}", :post => {:document => {'text' => '2'}, :created_at => Time.new(0)}
+        last_response.status.should eq 200
+        Time.parse(JSON.parse(last_response.body)['post']['created_at']).to_s.should eq p.created_at.to_s
+      end
+
       it "can't update a deleted external document" do
         p = Post.create!(:uid => "post:a.b.c", :document => {'text' => '1'}, :created_by => 1, :deleted => true, :external_id => 'foo_123')
         post "/posts/#{p.uid}", :post => {:document => {'text' => '2'}, :external_id => 'foo_123'}
@@ -629,5 +636,14 @@ describe "API v1 posts" do
       result = JSON.parse(last_response.body)['post']
       result['created_by'].should eq 1
     end
+
+    it "can update timestamps" do
+      p = Post.create!(:uid => "post:a.b.c", :document => {'text' => '1'}, :created_by => 1)
+      new_time = Time.now-60000
+      post "/posts/#{p.uid}", :post => {:document => {'text' => '2'}, :created_at => new_time}
+      last_response.status.should eq 200
+      Time.parse(JSON.parse(last_response.body)['post']['created_at']).to_s.should eq new_time.to_s
+    end
+
   end
 end


### PR DESCRIPTION
When importing data from external sources we need to be able to specify the created_at field.
