### PR TITLE
Merged document should return empty hash not nil if there is no content to return

### DIFF
--- a/lib/models/post.rb
+++ b/lib/models/post.rb
@@ -172,7 +172,7 @@ class Post < ActiveRecord::Base
 
   def merged_document
     doc = (external_document || {}).merge(document || {}).merge((occurrences.empty? ? {} : {'occurrences' => occurrences}))
-    doc.empty? ? nil : doc
+    doc.empty? ? {} : doc
   end
 
   def uid

--- a/spec/lib/models/occurences_property_spec.rb
+++ b/spec/lib/models/occurences_property_spec.rb
@@ -20,7 +20,7 @@ describe Post::OccurrencesAccessor do
   it "ignores occurrences if there are none" do
     p = Post.create!(:uid => "post:a.b.c")
     q = Post.find(p.id)
-    q.merged_document.should eq(nil)
+    q.merged_document.should eq({})
   end
 
   it "puts occurrences into the merged document" do


### PR DESCRIPTION
The API should return an empty hash for post.document - never null.
