### PR TITLE
Versioning

### DIFF
--- a/api/v1.rb
+++ b/api/v1.rb
@@ -62,4 +62,8 @@ class GroveV1 < Sinatra::Base
     end
   end
 
+  error ActiveRecord::StaleObjectError do |e|
+    halt 409, "Post has been modified; refetch and try again"
+  end
+
 end

--- a/api/v1/posts.rb
+++ b/api/v1/posts.rb
@@ -136,7 +136,13 @@ class GroveV1 < Sinatra::Base
     halt 404, "Post is deleted" if @post.deleted?
     response.status = 201 if @post.new_record?
 
-    allowed_attributes = ['external_document', 'document', 'sensitive', 'paths', 'occurrences', 'tags', 'external_id', 'restricted', 'published']
+    if attributes[:version] and @post.new_record?
+      halt 403, "You may not specify initial version when creating post"
+    end
+
+    allowed_attributes = ['external_document', 'document', 'sensitive', 'paths',
+      'occurrences', 'tags', 'external_id', 'restricted', 'published', 'version']
+
     # Gods have some extra fields they may update
     if current_identity.god?
       allowed_attributes += ['created_at', 'created_by', 'protected']

--- a/api/v1/views/post.pg
+++ b/api/v1/views/post.pg
@@ -1,7 +1,9 @@
 raw = self.raw if self.respond_to?(:raw)
 
 node :post => mypost do
-  attributes :uid, :created_by, :created_at, :updated_at, :deleted, :tags, :external_id, :paths, :restricted, :published, :conflicted, :protected
+  attributes :uid, :created_by, :created_at, :updated_at, :deleted,
+    :tags, :external_id, :paths, :restricted, :published, :conflicted,
+    :protected, :version
   node :id => mypost.uid
   if raw
     node document: mypost.document

--- a/db/migrate/20140905205824_add_version_column_to_posts.rb
+++ b/db/migrate/20140905205824_add_version_column_to_posts.rb
@@ -1,0 +1,7 @@
+class AddVersionColumnToPosts < ActiveRecord::Migration
+
+  def change
+    add_column :posts, :version, :integer, null: false, default: 1
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140211194851) do
+ActiveRecord::Schema.define(version: 20140905205824) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -93,6 +93,7 @@ ActiveRecord::Schema.define(version: 20140211194851) do
     t.text      "sensitive"
     t.timestamp "publish_at",                   precision: 6
     t.timestamp "expire_at",                    precision: 6
+    t.integer   "version",                                    default: 1,     null: false
   end
 
   add_index "posts", ["conflicted"], name: "index_posts_on_conflicted", using: :btree

--- a/lib/models/post.rb
+++ b/lib/models/post.rb
@@ -3,7 +3,11 @@ require_relative './post/document_validator'
 require_relative '../cache_key'
 
 class Post < ActiveRecord::Base
+
   class CanonicalPathConflict < StandardError; end
+
+  # Optimistic locking via version column
+  self.locking_column = 'version'
 
   include TsVectorTags
   include CacheKey

--- a/spec/api/v1/posts/versioning_spec.rb
+++ b/spec/api/v1/posts/versioning_spec.rb
@@ -1,0 +1,58 @@
+# encoding: utf-8
+
+require 'spec_helper'
+
+describe 'Versioning' do
+
+  include Rack::Test::Methods
+  include Pebblebed::RSpecHelper
+
+  def app
+    GroveV1.set disable_callbacks: true
+    GroveV1
+  end
+
+  before(:each) do
+    god!(:realm => 'a')
+  end
+
+  it 'assigns a new version number to each modification' do
+    post = Post.create!(uid: 'post:a.b.c',
+      document: {text: 'I can spel'})
+    post "/posts/#{post.uid}", post: {
+      document: {content: 'I DO can spell'}}
+    expect(last_response.status).to eq 200
+    expect(JSON.parse(last_response.body)['post']['version']).to be > post.version
+  end
+
+  it 'does not allow version number on create' do
+    post "/posts/post:a.b.c", post: {
+      version: 420,
+      document: {content: 'I DO can spell'}}
+    expect(last_response.status).to eq 403
+  end
+
+  it 'returns 200 when attempting to update correct version' do
+    post = Post.create!(uid: 'post:a.b.c',
+      document: {text: 'I can spel'})
+    expect(post.save).to be_true
+
+    post "/posts/#{post.uid}", post: {
+      version: post.version,
+      document: {content: 'I DO can spell'}}
+    expect(last_response.status).to eq 200
+  end
+
+  it 'returns 409 when attempting to update wrong version' do
+    post = Post.create!(uid: 'post:a.b.c',
+      document: {text: 'I can spel'})
+    original_version = post.version
+    expect(post.save).to be_true
+
+    post "/posts/#{post.uid}", post: {
+      version: original_version,
+      document: {content: 'I DO can spell'}}
+    expect(last_response.status).to eq 409
+  end
+
+end

--- a/spec/lib/models/posts_spec.rb
+++ b/spec/lib/models/posts_spec.rb
@@ -463,4 +463,19 @@ describe Post do
     end
   end
 
+  describe 'versioning' do
+    it 'assigns version initially' do
+      post = Post.create!(uid: 'post:a.b.c', document: {text: 'foo'})
+      expect(post.version).not_to be_nil
+    end
+
+    it 'increments version on update' do
+      post = Post.create!(uid: 'post:a.b.c', document: {text: 'foo'})
+      version = post.version
+      post.document = {text: 'bar'}
+      post.save!
+      expect(post.version).to be > version
+    end
+  end
+
 end


### PR DESCRIPTION
Add optimistic locking via a numeric version field.

If a client fetches a document with version 1, and then tries to post the same document (with the version 1 as part of the POST data), and another client has modified the document in the meantime, the request will fail.

**Note**: This branches from the `use_sinatra_activerecord_tasks` branch. :crying_cat_face: The relevant commit is f4e60f0bf4482572593e6f2d68aef4f6607ae0f3.
