### PR TITLE
Fix create event bug

### DIFF
--- a/spec/lib/river_notifications_spec.rb
+++ b/spec/lib/river_notifications_spec.rb
@@ -20,7 +20,8 @@ describe RiverNotifications do
         arg[:attributes]['version'].should eq 1
         arg[:changed_attributes].should be nil
       end
-      Post.create!(:canonical_path => 'this.that')
+      post = Post.create!(:canonical_path => 'this.that')
+      post.run_callbacks(:commit)
     end
 
   end


### PR DESCRIPTION
Grove is using the ActiveRecord hook `after_create` for sending `create` events in River. This means that external systems are notified before the object is available in the database, because the transaction has not completed by the time `after_create` triggers:

http://apidock.com/rails/ActiveRecord/Callbacks/after_create
> Is called after Base.save on new objects that haven’t been saved yet (no record exists). Note that this callback is still wrapped in the transaction around save. For example, if you invoke an external indexer at this point it won’t see the changes in the database.

The fix changes the Observer hook to `after_commit`, which fixes this issue. However, `after_commit` triggers after every commit to the database, so in order to distinguish create events, we need to reach into ActiveRecord internals to query the transaction type. Normally one would specify a condition to the hook in an ActiveRecord model like this

``` ruby
class Post < ActiveRecord::Base
  after_commit :some_method, on: :create
end
```

This is not possible in an Observer because hooks are specified as declared methods:

``` ruby
class RiverNotifications < ActiveRecord::Observer
  observe Post

  def after_commit(object)
  end
end
```

So we introduce a call to the private method `transaction_include_any_action?` which accepts an array of actions and returns `true` is the transaction involves any of them:

``` ruby
  def after_commit(object)
    if object.is_a?(Post) && object.send(:transaction_include_any_action?, [:create])
      prepare_for_publish(object, :create)
    end
  end
```

The pull request wraps this hackery in a private method that checks for availability of `transaction_include_any_action?` and raises an error if it disappears in a future upgrade.

In order for transactional tests to pass with this way of specifying hooks, we need to explicitly run the commit callbacks in the test

``` ruby
    it "runs commit callback even within the transactional tests" do
      post = Post.create!(:canonical_path => 'this.that')
      post.run_callbacks(:commit)
    end
```
